### PR TITLE
Don't update fast-forward position if it is the current position

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -156,10 +156,16 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, On
         @Override
         public void onClick(@NonNull View view) {
             int position = (int) view.getTag(TAG_KEY_POSITION);
-            state.updateFastForwardPosition(position);
+            if (notAlreadyAt(position)) {
+                state.updateFastForwardPosition(position);
+            }
             viewPager.setCurrentItem(position);
         }
     };
+
+    private boolean notAlreadyAt(int position) {
+        return position != state.getPosition();
+    }
 
     public interface TabSetterUpper {
         View setUp(int position, CharSequence title, View inflatedTab);


### PR DESCRIPTION
This fixes an issue where tapping the current title would no longer move the indicator

| Before | After |
| --- | --- |
| ![indicator-stuck](https://cloud.githubusercontent.com/assets/666285/7810900/014d63fc-039e-11e5-87c7-67472a39269a.gif) | ![indicator-unstuck](https://cloud.githubusercontent.com/assets/666285/7810908/0b9c59bc-039e-11e5-8280-6fd7cd39c1e8.gif) |
