### PR TITLE
Changes selected state for activated state

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
@@ -38,7 +38,7 @@ class ScrollingPageChangeListener implements ViewPager.OnPageChangeListener {
 
     private void handleAdapterSetBecausePageSelectedIsNotCalled(int position) {
         if (firstTimeAccessed) {
-            tabsContainer.setSelected(position);
+            tabsContainer.setActivated(position);
             firstTimeAccessed = false;
         }
     }
@@ -65,7 +65,7 @@ class ScrollingPageChangeListener implements ViewPager.OnPageChangeListener {
 
     @Override
     public void onPageSelected(int position) {
-        tabsContainer.setSelected(position);
+        tabsContainer.setActivated(position);
         onPageChangedListenerCollection.onPageSelected(position);
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
+++ b/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
@@ -71,10 +71,10 @@ class TabsContainer {
         return tabsContainerView.getChildCount();
     }
 
-    void setSelected(int position) {
+    void setActivated(int position) {
         for (int index = 0; index < getTabCount(); index++) {
             View tab = getTabAt(index);
-            tab.setSelected(index == position);
+            tab.setActivated(index == position);
         }
     }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -15,5 +15,5 @@ android {
 
 dependencies {
     compile project(":core")
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.2.0'
 }

--- a/demo/src/main/res/drawable/tab_custom_background.xml
+++ b/demo/src/main/res/drawable/tab_custom_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_activated="true" android:drawable="@android:color/holo_orange_light" />
+  <item android:drawable="@android:color/transparent" />
+</selector>

--- a/demo/src/main/res/layout/tab_custom.xml
+++ b/demo/src/main/res/layout/tab_custom.xml
@@ -3,6 +3,7 @@
   android:orientation="vertical"
   android:layout_width="wrap_content"
   android:layout_height="match_parent"
+  android:background="@drawable/tab_custom_background"
   android:minWidth="50dp">
 
   <TextView


### PR DESCRIPTION
I [researched a bit about different view states](http://ataulm.com/android-view-states/) and it seems where we set as _selected_, it should be _activated_.

This is an "API" breaking change, in that people who already react to `state_selected` will need to change to `state_activated`.

![activated](https://cloud.githubusercontent.com/assets/2678555/7948837/c0e510f2-097f-11e5-9f6d-418c0ff8decd.gif)

Fixes #3 !
