### PR TITLE
Upgrade design support lib version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 dependencies {
-    compile 'com.android.support:design:22.2.0'
+    compile 'com.android.support:design:22.2.1'
 }
 
 android {


### PR DESCRIPTION
Upgrade design support lib version to the max 22.x possible. We dont want to change for 23.x for now I guess.
