### PR TITLE
Reduce minSdkVersion to 15

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 15
         targetSdkVersion 22
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
+++ b/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
@@ -1,6 +1,8 @@
 package com.novoda.landingstrip;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
 import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -55,15 +57,18 @@ class TabsContainer {
 
     void startWatching(final ViewPager viewPager, final ViewPager.OnPageChangeListener onPageChangeListener) {
         if (hasTabs()) {
-            getTabAt(0).getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-                @Override
-                public void onGlobalLayout() {
-                    getTabAt(0).getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                    viewPager.addOnPageChangeListener(onPageChangeListener);
+            getTabAt(0).getViewTreeObserver().addOnGlobalLayoutListener(
+                    new ViewTreeObserver.OnGlobalLayoutListener() {
+                        @Override
+                        public void onGlobalLayout() {
+                            ViewTreeObserver observer = getTabAt(0).getViewTreeObserver();
+                            removeOnGlobalLayoutListener(observer, this);
+                            viewPager.addOnPageChangeListener(onPageChangeListener);
 
-                    onPageChangeListener.onPageScrolled(viewPager.getCurrentItem(), 0, 0);
-                }
-            });
+                            onPageChangeListener.onPageScrolled(viewPager.getCurrentItem(), 0, 0);
+                        }
+                    }
+            );
         }
     }
 
@@ -84,5 +89,23 @@ class TabsContainer {
 
     boolean hasTabAt(int position) {
         return getTabCount() - 1 >= position + 1;
+    }
+
+    private void removeOnGlobalLayoutListener(ViewTreeObserver observer, ViewTreeObserver.OnGlobalLayoutListener victim) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            removeOnGlobalLayoutListenerJellyBean(observer, victim);
+        } else {
+            removeOnGlobalLayoutListenerLegacy(observer, victim);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    private void removeOnGlobalLayoutListenerJellyBean(ViewTreeObserver observer, ViewTreeObserver.OnGlobalLayoutListener victim) {
+        observer.removeOnGlobalLayoutListener(victim);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void removeOnGlobalLayoutListenerLegacy(ViewTreeObserver observer, ViewTreeObserver.OnGlobalLayoutListener victim) {
+        observer.removeGlobalOnLayoutListener(victim);
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.novoda.landingstrip"
-        minSdkVersion 16
+        minSdkVersion 15
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
This PR changes `minSdkVersion` to 15 by adding a version-safe wrapper to remove an `OnGlobalLayoutListener` from a `ViewTreeObserver`.

There are no UI / UX changes.
