### PR TITLE
Use support-core-ui instead of support-v4

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 dependencies {
-    compile 'com.android.support:support-v4:24.1.1'
+    compile 'com.android.support:support-core-ui:24.2.1'
 }
 
 android {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -14,6 +14,8 @@ android {
 }
 
 dependencies {
-    compile project(":core")
+    compile (project(":core")) {
+        exclude group: 'com.android.support', module: 'support-core-ui'
+    }
     compile 'com.android.support:appcompat-v7:22.2.0'
 }


### PR DESCRIPTION
This PR is about using the minimum necessary for this lib to work. We depend mainly on `ViewPager` so we can simply depend on `support-core-ui` instead of `support-v4`.

Here's the comparison between the 2 (on www.methodscount.com):

 [support-core-ui](http://www.methodscount.com/?lib=com.android.support%3Asupport-core-ui%3A24.2.1)
[support-v4](http://www.methodscount.com/?lib=com.android.support%3Asupport-v4%3A24.1.1) 
