### PR TITLE
Remove too many listeners bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "1.0.2"
+    version = "1.0.1"
 }
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "1.0.1"
+    version = "1.0.2"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -28,8 +28,8 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
     private final TabsContainer tabsContainer;
     private final ScrollOffsetCalculator scrollOffsetCalculator;
     private final FastForwarder fastForwarder;
+    private final Set<ScrollingPageChangeListener> scrollingPageChangeListeners;
 
-    private Set<ScrollingPageChangeListener> onScrollingPageChangeListeners;
     private ViewPager viewPager;
     private TabSetterUpper tabSetterUpper;
     private OnPageChangedListenerCollection onPageChangeListenerCollection;
@@ -56,7 +56,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
         this.fastForwarder = new FastForwarder(state, this, scrollOffsetCalculator);
 
         this.onPageChangeListenerCollection = OnPageChangedListenerCollection.newInstance();
-        this.onScrollingPageChangeListeners = new HashSet<>();
+        this.scrollingPageChangeListeners = new HashSet<>();
         state.updatePosition(0);
         state.updatePositionOffset(0);
 
@@ -161,14 +161,14 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
     }
 
     private void removeAllListenersFrom(ViewPager viewPager) {
-        for (ScrollingPageChangeListener listener : onScrollingPageChangeListeners) {
+        for (ScrollingPageChangeListener listener : scrollingPageChangeListeners) {
             viewPager.removeOnPageChangeListener(listener);
         }
-        onScrollingPageChangeListeners.clear();
+        scrollingPageChangeListeners.clear();
     }
 
-    private void trackAttachedListener(ScrollingPageChangeListener scrollingPageChangeListener) {
-        onScrollingPageChangeListeners.add(scrollingPageChangeListener);
+    private void trackAttachedListener(ScrollingPageChangeListener listener) {
+        scrollingPageChangeListeners.add(listener);
     }
 
     private void addTab(final int position, CharSequence title, View tabView, TabSetterUpper tabSetterUpper) {

--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -12,8 +12,8 @@ import android.view.View;
 import android.widget.HorizontalScrollView;
 import android.widget.TextView;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 public class LandingStrip extends HorizontalScrollView implements Scrollable {
 
@@ -28,7 +28,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
     private final TabsContainer tabsContainer;
     private final ScrollOffsetCalculator scrollOffsetCalculator;
     private final FastForwarder fastForwarder;
-    private final Set<ScrollingPageChangeListener> scrollingPageChangeListeners;
+    private final List<ScrollingPageChangeListener> scrollingPageChangeListeners;
 
     private ViewPager viewPager;
     private TabSetterUpper tabSetterUpper;
@@ -56,7 +56,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
         this.fastForwarder = new FastForwarder(state, this, scrollOffsetCalculator);
 
         this.onPageChangeListenerCollection = OnPageChangedListenerCollection.newInstance();
-        this.scrollingPageChangeListeners = new HashSet<>();
+        this.scrollingPageChangeListeners = new ArrayList<>();
         state.updatePosition(0);
         state.updatePositionOffset(0);
 

--- a/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
+++ b/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
@@ -47,7 +47,7 @@ class TabsContainer {
         return tabsContainerView.getChildCount() > 0;
     }
 
-    View getTabAt(int position) {
+    View getTabAt(final int position) {
         return tabsContainerView.getChildAt(position);
     }
 
@@ -57,18 +57,13 @@ class TabsContainer {
 
     void startWatching(final ViewPager viewPager, final ViewPager.OnPageChangeListener onPageChangeListener) {
         if (hasTabs()) {
-            getTabAt(0).getViewTreeObserver().addOnGlobalLayoutListener(
-                    new ViewTreeObserver.OnGlobalLayoutListener() {
-                        @Override
-                        public void onGlobalLayout() {
-                            ViewTreeObserver observer = getTabAt(0).getViewTreeObserver();
-                            removeOnGlobalLayoutListener(observer, this);
-                            viewPager.addOnPageChangeListener(onPageChangeListener);
-
-                            onPageChangeListener.onPageScrolled(viewPager.getCurrentItem(), 0, 0);
-                        }
-                    }
-            );
+            viewPager.addOnPageChangeListener(onPageChangeListener);
+            viewPager.post(new Runnable() {
+                @Override
+                public void run() {
+                    onPageChangeListener.onPageScrolled(viewPager.getCurrentItem(), 0, 0);
+                }
+            });
         }
     }
 
@@ -89,23 +84,5 @@ class TabsContainer {
 
     boolean hasTabAt(int position) {
         return getTabCount() - 1 >= position + 1;
-    }
-
-    private void removeOnGlobalLayoutListener(ViewTreeObserver observer, ViewTreeObserver.OnGlobalLayoutListener victim) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            removeOnGlobalLayoutListenerJellyBean(observer, victim);
-        } else {
-            removeOnGlobalLayoutListenerLegacy(observer, victim);
-        }
-    }
-
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-    private void removeOnGlobalLayoutListenerJellyBean(ViewTreeObserver observer, ViewTreeObserver.OnGlobalLayoutListener victim) {
-        observer.removeOnGlobalLayoutListener(victim);
-    }
-
-    @SuppressWarnings("deprecation")
-    private void removeOnGlobalLayoutListenerLegacy(ViewTreeObserver observer, ViewTreeObserver.OnGlobalLayoutListener victim) {
-        observer.removeGlobalOnLayoutListener(victim);
     }
 }

--- a/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
+++ b/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
@@ -47,7 +47,7 @@ class TabsContainer {
         return tabsContainerView.getChildCount() > 0;
     }
 
-    View getTabAt(final int position) {
+    View getTabAt(int position) {
         return tabsContainerView.getChildAt(position);
     }
 

--- a/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
@@ -8,6 +8,9 @@ import com.novoda.landingstrip.setup.view.DemoViewPagerAdapter;
 
 public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
+    private LandingStrip landingStrip;
+    private ViewPager viewPager;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -15,11 +18,15 @@ public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_basic_usage);
 
-        ViewPager viewPager = (ViewPager) findViewById(R.id.view_pager);
+        viewPager = (ViewPager) findViewById(R.id.view_pager);
         viewPager.setAdapter(new DemoViewPagerAdapter(getLayoutInflater()));
 
-        LandingStrip landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
+        landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
         landingStrip.attach(viewPager);
     }
 
+    @Override
+    protected void onDestroy() {
+        landingStrip.detach(viewPager);
+    }
 }


### PR DESCRIPTION
## Problem ##

Using this library in an external project we have found out that we receive lots of events from the `onGlobalLayoutListener`
- Not all attached views receive events
- View receives more than one event

This is causing the application to trigger events for views that don't exist anymore and lingering listeners from views that never get detached

## Solution ##

- We have replaced the `onGlobalLayoutListener` by enqueing a runnable in the UI thread of the views.
- We keep track of all the listeners being attached to the `viewPager` so that the view doesn't hold invalid listeners.
- We have added a new method to the class `LandingStrip.detach(viewPager)` meant to destroy all listeners in order to prevent possible memory leaks.

Paired with @joetimmins @zegnus