### PR TITLE
Remove view pager from landing strip detach method

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -200,8 +200,10 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
         invalidate();
     }
 
-    public void detach(ViewPager viewPager) {
-        removeAllListenersFrom(viewPager);
+    public void detach() {
+        if (viewPager != null) {
+            removeAllListenersFrom(viewPager);
+        }
     }
 
     public interface TabSetterUpper {

--- a/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
@@ -27,6 +27,6 @@ public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        landingStrip.detach(viewPager);
+        landingStrip.detach();
     }
 }


### PR DESCRIPTION
We weren't detaching the viewPager originally attached to - changed to check if not null and detach correctly.