### PR TITLE
Bump gradle version and use detach() everywhere

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ allprojects {
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.novoda:bintray-release:0.2.7'
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,17 +2,17 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 dependencies {
-    compile 'com.android.support:support-core-ui:24.2.1'
+    compile 'com.android.support:support-core-ui:25.2.0'
 }
 
 android {
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 25
     }
 
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 }
 
 publish {

--- a/demo/src/main/java/com/novoda/landingstrip/CustomLandingStrip.java
+++ b/demo/src/main/java/com/novoda/landingstrip/CustomLandingStrip.java
@@ -8,17 +8,24 @@ import com.novoda.landingstrip.setup.fragment.DemoFragmentPagerAdapter;
 
 public class CustomLandingStrip extends AppCompatActivity {
 
+    private LandingStrip landingStrip;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_custom_landing_strip);
         setTitle("Demo: " + getClass().getSimpleName());
 
-        LandingStrip landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
+        landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
         ViewPager viewPager = (ViewPager) findViewById(R.id.view_pager);
         viewPager.setAdapter(new DemoFragmentPagerAdapter(getSupportFragmentManager()));
 
         landingStrip.attach(viewPager, viewPager.getAdapter());
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        landingStrip.detach();
+    }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/CustomLandingStrip.java
+++ b/demo/src/main/java/com/novoda/landingstrip/CustomLandingStrip.java
@@ -25,7 +25,7 @@ public class CustomLandingStrip extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         landingStrip.detach();
+        super.onDestroy();
     }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/CustomTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/CustomTabActivity.java
@@ -30,8 +30,8 @@ public class CustomTabActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         landingStrip.detach();
+        super.onDestroy();
     }
 
     private final LandingStrip.TabSetterUpper customTabs = new LandingStrip.TabSetterUpper() {

--- a/demo/src/main/java/com/novoda/landingstrip/CustomTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/CustomTabActivity.java
@@ -6,11 +6,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+
 import com.novoda.landing_strip.R;
 import com.novoda.landingstrip.setup.Data;
 import com.novoda.landingstrip.setup.fragment.DemoFragmentPagerAdapter;
 
 public class CustomTabActivity extends AppCompatActivity {
+
+    private LandingStrip landingStrip;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -18,11 +21,17 @@ public class CustomTabActivity extends AppCompatActivity {
         setContentView(R.layout.activity_custom_tab);
         setTitle("Demo: " + getClass().getSimpleName());
 
-        LandingStrip landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
+        landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
         ViewPager viewPager = (ViewPager) findViewById(R.id.view_pager);
         viewPager.setAdapter(new DemoFragmentPagerAdapter(getSupportFragmentManager()));
 
         landingStrip.attach(viewPager, viewPager.getAdapter(), customTabs);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        landingStrip.detach();
     }
 
     private final LandingStrip.TabSetterUpper customTabs = new LandingStrip.TabSetterUpper() {

--- a/demo/src/main/java/com/novoda/landingstrip/FixedWidthTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/FixedWidthTabActivity.java
@@ -26,7 +26,7 @@ public class FixedWidthTabActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         landingStrip.detach();
+        super.onDestroy();
     }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/FixedWidthTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/FixedWidthTabActivity.java
@@ -3,10 +3,13 @@ package com.novoda.landingstrip;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+
 import com.novoda.landing_strip.R;
 import com.novoda.landingstrip.setup.fragment.SmallDemoFragmentPagerAdapter;
 
 public class FixedWidthTabActivity extends AppCompatActivity {
+
+    private LandingStrip landingStrip;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -17,8 +20,13 @@ public class FixedWidthTabActivity extends AppCompatActivity {
         ViewPager viewPager = (ViewPager) findViewById(R.id.view_pager);
         viewPager.setAdapter(new SmallDemoFragmentPagerAdapter(getSupportFragmentManager()));
 
-        LandingStrip landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
+        landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
         landingStrip.attach(viewPager, viewPager.getAdapter());
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        landingStrip.detach();
+    }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
@@ -27,7 +27,7 @@ public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         landingStrip.detach();
+        super.onDestroy();
     }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
@@ -3,6 +3,7 @@ package com.novoda.landingstrip;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+
 import com.novoda.landing_strip.R;
 import com.novoda.landingstrip.setup.view.DemoViewPagerAdapter;
 
@@ -27,6 +28,7 @@ public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        super.onDestroy();
         landingStrip.detach();
     }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/NoFragmentsSimpleTextTabActivity.java
@@ -10,7 +10,6 @@ import com.novoda.landingstrip.setup.view.DemoViewPagerAdapter;
 public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
     private LandingStrip landingStrip;
-    private ViewPager viewPager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -19,7 +18,7 @@ public class NoFragmentsSimpleTextTabActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_basic_usage);
 
-        viewPager = (ViewPager) findViewById(R.id.view_pager);
+        ViewPager viewPager = (ViewPager) findViewById(R.id.view_pager);
         viewPager.setAdapter(new DemoViewPagerAdapter(getLayoutInflater()));
 
         landingStrip = (LandingStrip) findViewById(R.id.landing_strip);

--- a/demo/src/main/java/com/novoda/landingstrip/SimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/SimpleTextTabActivity.java
@@ -26,7 +26,7 @@ public class SimpleTextTabActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
         landingStrip.detach();
+        super.onDestroy();
     }
 }

--- a/demo/src/main/java/com/novoda/landingstrip/SimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/SimpleTextTabActivity.java
@@ -3,10 +3,13 @@ package com.novoda.landingstrip;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+
 import com.novoda.landing_strip.R;
 import com.novoda.landingstrip.setup.fragment.DemoFragmentPagerAdapter;
 
 public class SimpleTextTabActivity extends AppCompatActivity {
+
+    private LandingStrip landingStrip;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -17,8 +20,13 @@ public class SimpleTextTabActivity extends AppCompatActivity {
         ViewPager viewPager = (ViewPager) findViewById(R.id.view_pager);
         viewPager.setAdapter(new DemoFragmentPagerAdapter(getSupportFragmentManager()));
 
-        LandingStrip landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
+        landingStrip = (LandingStrip) findViewById(R.id.landing_strip);
         landingStrip.attach(viewPager, viewPager.getAdapter());
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        landingStrip.detach();
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri Feb 24 16:04:12 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
The previous PR https://github.com/novoda/landing-strip/pull/25 fixed an issue with the new `detach` method. So this PR makes every activity in the demo app actually make use of it.

Also bumps the gradle version so that we stay up to date with cool stuff like Instant Run!