### PR TITLE
Scroll direct to current item in ViewPager instead of posting a runnable to do it later

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -46,11 +46,11 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
         this.indicatorPaint = new Paint();
         this.indicatorCoordinatesCalculator = IndicatorCoordinatesCalculator.newInstance();
         this.pagerAdapterObserver = new PagerAdapterObserver(new OnPagerAdapterChangedListener() {
-                @Override
-                public void onPagerAdapterChanged(PagerAdapter pagerAdapter) {
-                    notifyDataSetChanged(pagerAdapter);
-                }
-            });
+            @Override
+            public void onPagerAdapterChanged(PagerAdapter pagerAdapter) {
+                notifyDataSetChanged(pagerAdapter);
+            }
+        });
         this.tabsContainer = TabsContainer.newInstance(context, attributes);
         this.scrollOffsetCalculator = new ScrollOffsetCalculator(tabsContainer);
         this.fastForwarder = new FastForwarder(state, this, scrollOffsetCalculator);
@@ -157,7 +157,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
                 scrollOffsetCalculator, this, fastForwarder, onPageChangeListenerCollection);
         removeAllListenersFrom(viewPager);
         trackAttachedListener(scrollingPageChangeListener);
-        tabsContainer.startWatching(viewPager, scrollingPageChangeListener);
+        tabsContainer.scrollToCurrentItem(viewPager, scrollingPageChangeListener);
     }
 
     private void removeAllListenersFrom(ViewPager viewPager) {

--- a/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
@@ -14,14 +14,18 @@ class ScrollOffsetCalculator {
     }
 
     int calculateScrollOffset(int position, float pagerOffset) {
-        View tabForPosition = tabsContainer.getTabAt(position);
+        if (!tabsContainer.hasTabAt(position)) {
+            return 0;
+        } else {
+            View tabForPosition = tabsContainer.getTabAt(position);
 
-        float tabStartX = tabForPosition.getLeft() + getHorizontalScrollOffset(position, pagerOffset);
-        float viewMiddleOffset = getTabParentWidth() * HALF_MULTIPLIER;
-        float tabCenterOffset = (tabForPosition.getRight() - tabForPosition.getLeft()) * HALF_MULTIPLIER;
-        float nextTabDelta = getNextTabDelta(position, pagerOffset, tabForPosition);
+            float tabStartX = tabForPosition.getLeft() + getHorizontalScrollOffset(tabForPosition, pagerOffset);
+            float viewMiddleOffset = getTabParentWidth() * HALF_MULTIPLIER;
+            float tabCenterOffset = (tabForPosition.getRight() - tabForPosition.getLeft()) * HALF_MULTIPLIER;
+            float nextTabDelta = getNextTabDelta(position, pagerOffset, tabForPosition);
 
-        return roundToInt(tabStartX - viewMiddleOffset + tabCenterOffset + nextTabDelta);
+            return roundToInt(tabStartX - viewMiddleOffset + tabCenterOffset + nextTabDelta);
+        }
     }
 
     private int roundToInt(float input) {
@@ -32,8 +36,8 @@ class ScrollOffsetCalculator {
         return tabsContainer.getParentWidth();
     }
 
-    private int getHorizontalScrollOffset(int position, float pagerOffset) {
-        int tabWidth = tabsContainer.getTabAt(position).getWidth();
+    private int getHorizontalScrollOffset(View tab, float pagerOffset) {
+        int tabWidth = tab.getWidth();
         return Math.round(pagerOffset * tabWidth);
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
+++ b/core/src/main/java/com/novoda/landingstrip/TabsContainer.java
@@ -1,13 +1,10 @@
 package com.novoda.landingstrip;
 
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
 import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
@@ -55,15 +52,10 @@ class TabsContainer {
         return !hasTabs();
     }
 
-    void startWatching(final ViewPager viewPager, final ViewPager.OnPageChangeListener onPageChangeListener) {
+    void scrollToCurrentItem(final ViewPager viewPager, final ViewPager.OnPageChangeListener onPageChangeListener) {
         if (hasTabs()) {
             viewPager.addOnPageChangeListener(onPageChangeListener);
-            viewPager.post(new Runnable() {
-                @Override
-                public void run() {
-                    onPageChangeListener.onPageScrolled(viewPager.getCurrentItem(), 0, 0);
-                }
-            });
+            onPageChangeListener.onPageScrolled(viewPager.getCurrentItem(), 0, 0);
         }
     }
 
@@ -83,6 +75,6 @@ class TabsContainer {
     }
 
     boolean hasTabAt(int position) {
-        return getTabCount() - 1 >= position + 1;
+        return position < getTabCount();
     }
 }


### PR DESCRIPTION
## Problem
With `landing-strip` v1.0.3 we were seeing some flickering effects in our layouts when the items in the underlying ViewPager were being update frequently. This was because we were relying on `Runnable`s in `landing-strip` to scroll to the current item, which was only happening after the full layout pass had been completed and the tab strip was selecting the first tab again.

## Solution
Rather than using a `Runnable` we now just directly call the `onScroll` method as soon as the tabs have been added to the `TabContainer`. Sometimes this happens too quickly and the desired tab has not been laid out yet, so we check for that occurrence in `ScrollOffsetCalculator`.