### PR TITLE
Bump version number to 1.0.4 for release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "1.0.3"
+    version = "1.0.4"
 }
 
 buildscript {


### PR DESCRIPTION
We need to use the changes added in https://github.com/novoda/landing-strip/pull/30, so this PR will increase the version number so we can release to bintray.