### PR TITLE
V2 - Modularising the OnPageChangeListener

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -41,19 +41,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
         tabsContainerView.setPadding(attributes.getTabsPaddingLeft(), 0, attributes.getTabsPaddingRight(), 0);
         addView(tabsContainerView);
 
-        ScrollOffsetCalculator scrollOffsetCalculator = new ScrollOffsetCalculator(this, tabsContainerView);
-        FastForwarder fastForwarder = new FastForwarder(state, this, scrollOffsetCalculator);
-
-        ScrollingPageChangeListener scrollingPageChangeListener = new ScrollingPageChangeListener(
-                state,
-                tabsContainerView,
-                scrollOffsetCalculator,
-                this,
-                fastForwarder
-        );
-
         notifier = new Notifier(tabsContainerView);
-        // do something with this
     }
 
     public <T extends View> void setAdapter(LandingStripAdapter<T> adapter) {
@@ -125,4 +113,11 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable {
         invalidate();
     }
 
+    MutableState getMutableState() {
+        return state;
+    }
+
+    public TabsContainerView getTabsContainer() {
+        return tabsContainerView;
+    }
 }

--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -4,12 +4,11 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.support.annotation.NonNull;
-import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.HorizontalScrollView;
 
-public class LandingStrip extends HorizontalScrollView implements Scrollable, ViewPager.OnPageChangeListener {
+public class LandingStrip extends HorizontalScrollView implements Scrollable {
 
     private final Attributes attributes;
     private final Paint indicatorPaint;
@@ -17,7 +16,6 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
     private final IndicatorCoordinatesCalculator indicatorCoordinatesCalculator;
 
     private TabsContainerView tabsContainerView;
-    private ScrollingPageChangeListener scrollingPageChangeListener;
     private Notifier notifier;
 
     public LandingStrip(Context context, AttributeSet attrs) {
@@ -46,7 +44,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
         ScrollOffsetCalculator scrollOffsetCalculator = new ScrollOffsetCalculator(this, tabsContainerView);
         FastForwarder fastForwarder = new FastForwarder(state, this, scrollOffsetCalculator);
 
-        this.scrollingPageChangeListener = new ScrollingPageChangeListener(
+        ScrollingPageChangeListener scrollingPageChangeListener = new ScrollingPageChangeListener(
                 state,
                 tabsContainerView,
                 scrollOffsetCalculator,
@@ -55,6 +53,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
         );
 
         notifier = new Notifier(tabsContainerView);
+        // do something with this
     }
 
     public <T extends View> void setAdapter(LandingStripAdapter<T> adapter) {
@@ -124,21 +123,6 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
     public void scrollTo(int x, int y) {
         super.scrollTo(x, y);
         invalidate();
-    }
-
-    @Override
-    public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-        scrollingPageChangeListener.onPageScrolled(position, positionOffset, positionOffsetPixels);
-    }
-
-    @Override
-    public void onPageSelected(int position) {
-        scrollingPageChangeListener.onPageSelected(position);
-    }
-
-    @Override
-    public void onPageScrollStateChanged(int state) {
-        scrollingPageChangeListener.onPageScrollStateChanged(state);
     }
 
 }

--- a/core/src/main/java/com/novoda/landingstrip/LandingStripPageChangeListener.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStripPageChangeListener.java
@@ -1,0 +1,21 @@
+package com.novoda.landingstrip;
+
+import android.support.v4.view.ViewPager;
+
+public class LandingStripPageChangeListener {
+
+    public static ViewPager.OnPageChangeListener create(LandingStrip landingStrip) {
+        TabsContainerView tabsContainer = landingStrip.getTabsContainer();
+        ScrollOffsetCalculator scrollOffsetCalculator = new ScrollOffsetCalculator(landingStrip, tabsContainer);
+        MutableState mutableState = landingStrip.getMutableState();
+        FastForwarder fastForwarder = new FastForwarder(mutableState, landingStrip, scrollOffsetCalculator);
+        return new ScrollingPageChangeListener(
+                mutableState,
+                tabsContainer,
+                scrollOffsetCalculator,
+                landingStrip,
+                fastForwarder
+        );
+    }
+
+}

--- a/demo/src/main/java/com/novoda/landingstrip/SimpleTextTabActivity.java
+++ b/demo/src/main/java/com/novoda/landingstrip/SimpleTextTabActivity.java
@@ -39,8 +39,8 @@ public class SimpleTextTabActivity extends AppCompatActivity {
             }
         };
         ExampleTabAdapter tabAdapter = new ExampleTabAdapter(getLayoutInflater(), setCurrentItemOnClick, data);
-
-        viewPager.addOnPageChangeListener(landingStrip);
+        ViewPager.OnPageChangeListener landingStripPageChanger = LandingStripPageChangeListener.create(landingStrip);
+        viewPager.addOnPageChangeListener(landingStripPageChanger);
         landingStrip.setAdapter(tabAdapter);
     }
 


### PR DESCRIPTION
Following the outcome of https://github.com/novoda/landing-strip/pull/32#discussion_r107132578

Removes the `OnPagechangeListener` from the `LandingStrip`, means exposing the `mutableState` and `tabsContainerView` via package local getters.

Api becomes

```
ViewPager.OnPageChangeListener landingStripPageChanger = LandingStripPageChangeListener.create(landingStrip);
viewPager.addOnPageChangeListener(landingStripPageChanger);
```

We'll eventually want to create a helper `attacher` to _hide_ all of this
