### PR TITLE
V2 - Applying Type to Notifier and Listener

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -18,7 +18,6 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
 
     private TabsContainerView tabsContainerView;
     private ScrollingPageChangeListener scrollingPageChangeListener;
-    private Notifier notifier;
 
     public LandingStrip(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -53,11 +52,10 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
                 this,
                 fastForwarder
         );
-
-        notifier = new Notifier(tabsContainerView);
     }
 
     public <T extends View> void setAdapter(LandingStripAdapter<T> adapter) {
+        Notifier<T> notifier = new Notifier<T>(tabsContainerView);
         adapter.setListener(notifier);
         adapter.notifyDataSetChanged();
     }

--- a/core/src/main/java/com/novoda/landingstrip/LandingStripAdapter.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStripAdapter.java
@@ -5,13 +5,13 @@ import android.view.ViewGroup;
 
 public abstract class LandingStripAdapter<T extends View> {
 
-    private Listener listener;
+    private Listener<T> listener;
 
     protected abstract T createView(ViewGroup parent, int position);
 
     protected abstract void bindView(T view, int position);
 
-    void setListener(Listener listener) {
+    void setListener(Listener<T> listener) {
         this.listener = listener;
     }
 
@@ -29,10 +29,10 @@ public abstract class LandingStripAdapter<T extends View> {
 
     protected abstract int getCount();
 
-    interface Listener {
+    interface Listener<T extends View> {
 
-        <T extends View> void onNotifyDataSetChanged(LandingStripAdapter<T> adapter);
+        void onNotifyDataSetChanged(LandingStripAdapter<T> adapter);
 
-        <T extends View> void onNotifyItemChanged(LandingStripAdapter<T> adapter, int position);
+        void onNotifyItemChanged(LandingStripAdapter<T> adapter, int position);
     }
 }

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -2,7 +2,7 @@ package com.novoda.landingstrip;
 
 import android.view.View;
 
-class Notifier implements LandingStripAdapter.Listener {
+class Notifier<T extends View> implements LandingStripAdapter.Listener<T> {
 
     private final TabsContainerView tabsContainerView;
 
@@ -11,11 +11,11 @@ class Notifier implements LandingStripAdapter.Listener {
     }
 
     @Override
-    public <T extends View> void onNotifyDataSetChanged(LandingStripAdapter<T> adapter) {
+    public void onNotifyDataSetChanged(LandingStripAdapter<T> adapter) {
         recreateAndBindTabs(adapter);
     }
 
-    private <T extends View> void recreateAndBindTabs(LandingStripAdapter<T> adapter) {
+    private void recreateAndBindTabs(LandingStripAdapter<T> adapter) {
         tabsContainerView.removeAllViews();
 
         for (int position = 0; position < adapter.getCount(); position++) {
@@ -26,7 +26,7 @@ class Notifier implements LandingStripAdapter.Listener {
     }
 
     @Override
-    public <T extends View> void onNotifyItemChanged(LandingStripAdapter<T> adapter, int position) {
+    public void onNotifyItemChanged(LandingStripAdapter<T> adapter, int position) {
         View tabView = tabsContainerView.getChildAt(position);
         adapter.bindView((T) tabView, position);
     }


### PR DESCRIPTION
Following the outcome of https://github.com/novoda/landing-strip/pull/32#discussion_r107132905

Gives the internal `Notifier` and `Listener` a fixed Type instead of allowing a dynamic type.

No public api changes.