### PR TITLE
V2 - ScrollOffsetCalculator tidy

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/FastForwarder.java
+++ b/core/src/main/java/com/novoda/landingstrip/FastForwarder.java
@@ -30,7 +30,10 @@ class FastForwarder {
     void fastForward() {
         fastForwarding = true;
 
-        animateToTab(state.fastForwardPosition());
+        int fastForwardPosition = state.fastForwardPosition();
+        if (fastForwardPosition != BYPASS_FAST_FORWARD) {
+            animateToTab(fastForwardPosition);
+        }
     }
 
     private void animateToTab(int newPosition) {

--- a/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
@@ -42,7 +42,9 @@ class ScrollOffsetCalculator {
 
     private float getNextTabDelta(int position, float pagerOffset, View tabForPosition) {
         if (hasTabAt(position + 1)) {
-            return (((tabsContainer.getChildAt(position + 1).getWidth()) - tabForPosition.getWidth()) * pagerOffset) * HALF_MULTIPLIER;
+            View nextTab = tabsContainer.getChildAt(position + 1);
+            int tabWidthDelta = (nextTab.getWidth()) - tabForPosition.getWidth();
+            return (tabWidthDelta * pagerOffset) * HALF_MULTIPLIER;
         }
         return 0F;
     }

--- a/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
@@ -17,18 +17,14 @@ class ScrollOffsetCalculator {
     }
 
     int calculateScrollOffset(int position, float pagerOffset) {
-        if (!hasTabAt(position)) {
-            return 0;
-        } else {
-            View tabForPosition = tabsContainer.getChildAt(position);
+        View tabForPosition = tabsContainer.getChildAt(position);
 
-            float tabStartX = tabForPosition.getLeft() + getHorizontalScrollOffset(tabForPosition, pagerOffset);
-            float viewMiddleOffset = rootView.getWidth() * HALF_MULTIPLIER;
-            float tabCenterOffset = (tabForPosition.getRight() - tabForPosition.getLeft()) * HALF_MULTIPLIER;
-            float nextTabDelta = getNextTabDelta(position, pagerOffset, tabForPosition);
+        float tabStartX = tabForPosition.getLeft() + getHorizontalScrollOffset(tabForPosition, pagerOffset);
+        float viewMiddleOffset = rootView.getWidth() * HALF_MULTIPLIER;
+        float tabCenterOffset = (tabForPosition.getRight() - tabForPosition.getLeft()) * HALF_MULTIPLIER;
+        float nextTabDelta = getNextTabDelta(position, pagerOffset, tabForPosition);
 
-            return roundToInt(tabStartX - viewMiddleOffset + tabCenterOffset + nextTabDelta);
-        }
+        return roundToInt(tabStartX - viewMiddleOffset + tabCenterOffset + nextTabDelta);
     }
 
     private int roundToInt(float input) {

--- a/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollOffsetCalculator.java
@@ -22,7 +22,7 @@ class ScrollOffsetCalculator {
         } else {
             View tabForPosition = tabsContainer.getChildAt(position);
 
-            float tabStartX = tabForPosition.getLeft() + getHorizontalScrollOffset(position, pagerOffset);
+            float tabStartX = tabForPosition.getLeft() + getHorizontalScrollOffset(tabForPosition, pagerOffset);
             float viewMiddleOffset = rootView.getWidth() * HALF_MULTIPLIER;
             float tabCenterOffset = (tabForPosition.getRight() - tabForPosition.getLeft()) * HALF_MULTIPLIER;
             float nextTabDelta = getNextTabDelta(position, pagerOffset, tabForPosition);
@@ -35,8 +35,8 @@ class ScrollOffsetCalculator {
         return (int) (input + ROUNDING_OFFSET);
     }
 
-    private int getHorizontalScrollOffset(int position, float pagerOffset) {
-        int tabWidth = tabsContainer.getChildAt(position).getWidth();
+    private int getHorizontalScrollOffset(View tab, float pagerOffset) {
+        int tabWidth = tab.getWidth();
         return Math.round(pagerOffset * tabWidth);
     }
 


### PR DESCRIPTION
- Removes unnecessary `hasTab` guard from calculating the offset, it was only crashing when called too early by `OnGlobalLayout` which has since been removed. 

- Extracts some intermediate variables for the tab delta calculation.

- Adds a `state` guard when fastforwarding to avoid a fastforward attempt using the `BYPASS` as a value.

- Reuses the exists `View tabForPositiob` instead of rereading it.