### PR TITLE
V2 - Initial tab activation

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -55,7 +55,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
     }
 
     public <T extends View> void setAdapter(BaseAdapter<T> adapter) {
-        Notifier<T> notifier = new Notifier<T>(tabsContainerView);
+        Notifier<T> notifier = new Notifier<T>(tabsContainerView, state);
         adapter.setListener(notifier);
         adapter.notifyDataSetChanged();
     }

--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -75,6 +75,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
     private void forceDrawIndicatorAtPosition(int position) {
         state.updatePosition(position);
         state.updatePositionOffset(0);
+        tabsContainerView.setActivated(position);
         invalidate();
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -126,11 +126,17 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+        if (tabsContainerView.getChildCount() == 0) {
+            return;
+        }
         scrollingPageChangeListener.onPageScrolled(position, positionOffset, positionOffsetPixels);
     }
 
     @Override
     public void onPageSelected(int position) {
+        if (tabsContainerView.getChildCount() == 0) {
+            return;
+        }
         scrollingPageChangeListener.onPageSelected(position);
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/MutableState.java
+++ b/core/src/main/java/com/novoda/landingstrip/MutableState.java
@@ -6,6 +6,7 @@ class MutableState implements State {
     private int position;
     private int fastForwardPosition;
     private boolean firstTimeAccessed;
+    private int selectedPosition;
 
     public static MutableState newInstance() {
         MutableState state = new MutableState();
@@ -34,6 +35,10 @@ class MutableState implements State {
         this.firstTimeAccessed = firstTimeAccessed;
     }
 
+    public void updateSelectedPosition(int selectedPosition) {
+        this.selectedPosition = selectedPosition;
+    }
+
     @Override
     public float offset() {
         return pagePositionOffset;
@@ -52,5 +57,10 @@ class MutableState implements State {
     @Override
     public boolean firstTimeAccessed() {
         return firstTimeAccessed;
+    }
+
+    @Override
+    public int selectedPosition() {
+        return selectedPosition;
     }
 }

--- a/core/src/main/java/com/novoda/landingstrip/MutableState.java
+++ b/core/src/main/java/com/novoda/landingstrip/MutableState.java
@@ -5,7 +5,6 @@ class MutableState implements State {
     private float pagePositionOffset;
     private int position;
     private int fastForwardPosition;
-    private boolean firstTimeAccessed;
     private int selectedPosition;
 
     public static MutableState newInstance() {
@@ -14,7 +13,6 @@ class MutableState implements State {
         state.updateFastForwardPosition(FastForwarder.BYPASS_FAST_FORWARD);
         state.updatePosition(0);
         state.updatePositionOffset(0f);
-        state.updateFirstTimeAccessed(true);
 
         return state;
     }
@@ -29,10 +27,6 @@ class MutableState implements State {
 
     public void updateFastForwardPosition(int fastForwardPosition) {
         this.fastForwardPosition = fastForwardPosition;
-    }
-
-    public void updateFirstTimeAccessed(boolean firstTimeAccessed) {
-        this.firstTimeAccessed = firstTimeAccessed;
     }
 
     public void updateSelectedPosition(int selectedPosition) {
@@ -52,11 +46,6 @@ class MutableState implements State {
     @Override
     public int fastForwardPosition() {
         return fastForwardPosition;
-    }
-
-    @Override
-    public boolean firstTimeAccessed() {
-        return firstTimeAccessed;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -29,8 +29,8 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
     }
 
     private void handleAdapterSetBecausePageSelectedIsNotCalled(BaseAdapter<T> adapter) {
-        if (state.firstTimeAccessed() && adapter.getCount() > 0) {
-            tabsContainerView.setActivated(state.position());
+        if (adapter.getCount() > 0) {
+            tabsContainerView.setActivated(state.selectedPosition());
             state.updateFirstTimeAccessed(false);
         }
     }

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -15,7 +15,7 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
     @Override
     public void onNotifyDataSetChanged(BaseAdapter<T> adapter) {
         recreateAndBindTabs(adapter);
-        handleAdapterSetBecausePageSelectedIsNotCalled(adapter);
+        initializeSelectedPosition();
     }
 
     private void recreateAndBindTabs(BaseAdapter<T> adapter) {
@@ -28,11 +28,9 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
         }
     }
 
-    private void handleAdapterSetBecausePageSelectedIsNotCalled(BaseAdapter<T> adapter) {
-        if (adapter.getCount() > 0) {
-            tabsContainerView.setActivated(state.selectedPosition());
-            state.updateFirstTimeAccessed(false);
-        }
+    private void initializeSelectedPosition() {
+        tabsContainerView.setActivated(state.selectedPosition());
+        state.updateFirstTimeAccessed(false);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -30,7 +30,6 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
 
     private void initializeSelectedPosition() {
         tabsContainerView.setActivated(state.selectedPosition());
-        state.updateFirstTimeAccessed(false);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -28,17 +28,18 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
         }
     }
 
+    @Override
+    public void onNotifyItemChanged(BaseAdapter<T> adapter, int position) {
+        View tabView = tabsContainerView.getChildAt(position);
+        adapter.bindView((T) tabView, position);
+        handleAdapterSetBecausePageSelectedIsNotCalled(adapter);
+    }
+
     private void handleAdapterSetBecausePageSelectedIsNotCalled(BaseAdapter<T> adapter) {
         if (state.firstTimeAccessed() && adapter.getCount() > 0) {
             tabsContainerView.setActivated(state.position());
             state.updateFirstTimeAccessed(false);
         }
-    }
-
-    @Override
-    public void onNotifyItemChanged(BaseAdapter<T> adapter, int position) {
-        View tabView = tabsContainerView.getChildAt(position);
-        adapter.bindView((T) tabView, position);
     }
 
 }

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -15,7 +15,7 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
     @Override
     public void onNotifyDataSetChanged(BaseAdapter<T> adapter) {
         recreateAndBindTabs(adapter);
-        handleAdapterSetBecausePageSelectedIsNotCalled();
+        handleAdapterSetBecausePageSelectedIsNotCalled(adapter);
     }
 
     private void recreateAndBindTabs(BaseAdapter<T> adapter) {
@@ -28,8 +28,8 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
         }
     }
 
-    private void handleAdapterSetBecausePageSelectedIsNotCalled() {
-        if (state.firstTimeAccessed()) {
+    private void handleAdapterSetBecausePageSelectedIsNotCalled(BaseAdapter<T> adapter) {
+        if (state.firstTimeAccessed() && adapter.getCount() > 0) {
             tabsContainerView.setActivated(state.position());
             state.updateFirstTimeAccessed(false);
         }

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -5,14 +5,17 @@ import android.view.View;
 class Notifier<T extends View> implements BaseAdapter.Listener<T> {
 
     private final TabsContainerView tabsContainerView;
+    private final MutableState state;
 
-    Notifier(TabsContainerView tabsContainerView) {
+    Notifier(TabsContainerView tabsContainerView, MutableState state) {
         this.tabsContainerView = tabsContainerView;
+        this.state = state;
     }
 
     @Override
     public void onNotifyDataSetChanged(BaseAdapter<T> adapter) {
         recreateAndBindTabs(adapter);
+        handleAdapterSetBecausePageSelectedIsNotCalled();
     }
 
     private void recreateAndBindTabs(BaseAdapter<T> adapter) {
@@ -22,6 +25,13 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
             T view = adapter.createView(tabsContainerView, position);
             adapter.bindView(view, position);
             tabsContainerView.addView(view);
+        }
+    }
+
+    private void handleAdapterSetBecausePageSelectedIsNotCalled() {
+        if (state.firstTimeAccessed()) {
+            tabsContainerView.setActivated(state.position());
+            state.updateFirstTimeAccessed(false);
         }
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/Notifier.java
+++ b/core/src/main/java/com/novoda/landingstrip/Notifier.java
@@ -28,18 +28,17 @@ class Notifier<T extends View> implements BaseAdapter.Listener<T> {
         }
     }
 
-    @Override
-    public void onNotifyItemChanged(BaseAdapter<T> adapter, int position) {
-        View tabView = tabsContainerView.getChildAt(position);
-        adapter.bindView((T) tabView, position);
-        handleAdapterSetBecausePageSelectedIsNotCalled(adapter);
-    }
-
     private void handleAdapterSetBecausePageSelectedIsNotCalled(BaseAdapter<T> adapter) {
         if (state.firstTimeAccessed() && adapter.getCount() > 0) {
             tabsContainerView.setActivated(state.position());
             state.updateFirstTimeAccessed(false);
         }
+    }
+
+    @Override
+    public void onNotifyItemChanged(BaseAdapter<T> adapter, int position) {
+        View tabView = tabsContainerView.getChildAt(position);
+        adapter.bindView((T) tabView, position);
     }
 
 }

--- a/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
@@ -53,6 +53,7 @@ class ScrollingPageChangeListener implements ViewPager.OnPageChangeListener {
 
     @Override
     public void onPageSelected(int position) {
+        state.updateSelectedPosition(position);
         tabsContainerView.setActivated(position);
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
@@ -24,19 +24,10 @@ class ScrollingPageChangeListener implements ViewPager.OnPageChangeListener {
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-        handleAdapterSetBecausePageSelectedIsNotCalled(position);
-
         if (shouldHandleFastForward()) {
             handleFastForward(position, positionOffset);
         } else {
             scroll(position, positionOffset);
-        }
-    }
-
-    private void handleAdapterSetBecausePageSelectedIsNotCalled(int position) {
-        if (state.firstTimeAccessed()) {
-            tabsContainerView.setActivated(position);
-            state.updateFirstTimeAccessed(false);
         }
     }
 

--- a/core/src/main/java/com/novoda/landingstrip/State.java
+++ b/core/src/main/java/com/novoda/landingstrip/State.java
@@ -8,7 +8,5 @@ interface State {
 
     int fastForwardPosition();
 
-    boolean firstTimeAccessed();
-
     int selectedPosition();
 }

--- a/core/src/main/java/com/novoda/landingstrip/State.java
+++ b/core/src/main/java/com/novoda/landingstrip/State.java
@@ -9,4 +9,6 @@ interface State {
     int fastForwardPosition();
 
     boolean firstTimeAccessed();
+
+    int selectedPosition();
 }

--- a/demo/src/main/res/color/tab_text_color.xml
+++ b/demo/src/main/res/color/tab_text_color.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="@android:color/white"
+    android:state_activated="true" />
+  <item android:color="@android:color/black" />
+</selector>

--- a/demo/src/main/res/layout/tab_simple_text.xml
+++ b/demo/src/main/res/layout/tab_simple_text.xml
@@ -2,6 +2,7 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="wrap_content"
   android:layout_height="match_parent"
+  android:textColor="@color/tab_text_color"
   android:gravity="center"
   android:minWidth="50dp"
   android:textSize="18dp" />


### PR DESCRIPTION
Fixes crash when not setting/updating the landingstrip adapter before setting a viewpager adapter after setting the `landingstrip` as a `onPageChangedListener` -

`viewpager.setAdapter` triggers `onPageScrolled` however we may not have set or updated a `TabAdapter` with content causing the `ScrollingPageChangeListener` to crash as the `TabContainerView` contains no tabs! 

fixed by guarding the `OnPageChangedListener` methods with `tabsContainerView.getChildCount() == 0`

Fixes initial tab activated state being skipped -

By ignoring scroll events when the tabs are missing, we broke the initial tab activation state from being set due to a hidden race condition in `onPageScrolled -> TabsContainerView.setActivated`

This is fixed by moving the initial tab activation state to after notifying/creating the tabs and by introducing a new state `selectedPosition` which is used to restore the position state