### PR TITLE
Store selected position onPageSelected even prior to tab adapter set

### DIFF
--- a/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
+++ b/core/src/main/java/com/novoda/landingstrip/LandingStrip.java
@@ -61,15 +61,8 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
     }
 
     public void setCurrentItem(int position) {
-        if (alreadyAt(position)) {
-            return;
-        }
         state.updateFastForwardPosition(position);
         forceDrawIndicatorAtPosition(position);
-    }
-
-    private boolean alreadyAt(int position) {
-        return position != state.position();
     }
 
     private void forceDrawIndicatorAtPosition(int position) {
@@ -135,6 +128,7 @@ public class LandingStrip extends HorizontalScrollView implements Scrollable, Vi
 
     @Override
     public void onPageSelected(int position) {
+        state.updateSelectedPosition(position);
         if (tabsContainerView.getChildCount() == 0) {
             return;
         }

--- a/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
+++ b/core/src/main/java/com/novoda/landingstrip/ScrollingPageChangeListener.java
@@ -53,7 +53,6 @@ class ScrollingPageChangeListener implements ViewPager.OnPageChangeListener {
 
     @Override
     public void onPageSelected(int position) {
-        state.updateSelectedPosition(position);
         tabsContainerView.setActivated(position);
     }
 


### PR DESCRIPTION
## This PR

Fixes an issue where the indicator is at the correct position, but the tab it's under has not been activated.

## Approach

We discovered this in one of our host apps where we call `viewpager.setCurrentItem` _before_ we've set `landingStrip.setAdapter`.

Now we keep note of the `onPageSelected` callback from the page change listener, so that when we do get the tab adapter, and draw the tabs, we'll know which tab was selected.

It means that we don't have to require the order of landingStrip.setAdapter/viewPager.setCurrentItem, though probably it would make sense from the client point of view to set up the viewpager and tabs before changing the page.

Before | After
--- | ---
![screenshot_1518517621](https://user-images.githubusercontent.com/2678555/36147775-71e74aec-10b1-11e8-9eea-b508b83dc746.png) | ![screenshot_1518517314](https://user-images.githubusercontent.com/2678555/36147777-753b36c2-10b1-11e8-855a-2774aeca00d5.png)

